### PR TITLE
Fix makefile and update httplib2 to 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,17 @@
-VIRTUAL_ENV_DIR=vendor/python
-BOTO_VIRTUAL_ENV_DIR=vendor/boto
-PIP_CMD=PIP_DOWNLOAD_CACHE=vendor/cache $(VIRTUAL_ENV_DIR)/bin/pip install --no-deps -i http://pypi.utils.globuscs.info/simple -r 
+VIRTUAL_ENV_DIR=dist
+PIP_CMD=$(VIRTUAL_ENV_DIR)/bin/pip install --no-deps -r 
 DEPLOY_PIP_CMD=PIP_DOWNLOAD_CACHE=vendor/cache $(VIRTUAL_ENV_DIR)/bin/pip install --no-deps -r 
 
 .PHONY: build
-build: $(VIRTUAL_ENV_DIR)/lib/python2.7/site-packages/goauth
+build: $(VIRTUAL_ENV_DIR) requirements.txt
 
-$(VIRTUAL_ENV_DIR)/lib/python2.7/site-packages/goauth/: vendor/virtualenv.py
-	python vendor/virtualenv.py --python python2.7 --no-site-packages $(VIRTUAL_ENV_DIR)
+$(VIRTUAL_ENV_DIR):
+	virtualenv --python python2.7 --no-site-packages $(VIRTUAL_ENV_DIR)
 	$(PIP_CMD) requirements.txt
-	vendor/python/bin/python setup.py install
-
-vendor/virtualenv.py:
-	curl -o vendor/virtualenv.py https://raw.github.com/pypa/virtualenv/master/virtualenv.py
+	$(VIRTUAL_ENV_DIR)/bin/python setup.py install
 
 clean:
 	rm -rf $(VIRTUAL_ENV_DIR)
-	rm -rf build
-	rm -rf dist
-	rm -rf gearbox
-	rm -rf *.egg
 	find ./ -name "*.pyc" -delete
 
 test: build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httplib2==0.7.1
+httplib2==0.9.0
 oauth2==1.5.167
 requests==1.2.3
 PyYAML==3.10


### PR DESCRIPTION
The commit message is not particularly informative on this, so a little bit of explanation is probably warranted.

I needed a version of this which installed cleanly for some of the Globus Genomics automation.
Since PyPi no longer serves httplib v0.7.1, I had to bump it to a newer version. I chose to be conservative because the current testsuite fails, but perhaps the dependency can be removed altogether? In any case, this works cleanly for a `pip install git+https://...`

I did the Makefile fixes in order to be able to run the tests, which didn't give any confidence, as they failed with either version of httplib.
