### PR TITLE
Add redirect_uri as optional param when getting Access Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 python-nexus-client
 ===================
 
-Python client for interacting with GlobusOnline Nexus service.
+Example python client for interacting with Globus Nexus service.
 
 The main entry point to this library is nexus.Client.  This allows
 access to all of the main methods.

--- a/lib/nexus/go_rest_client.py
+++ b/lib/nexus/go_rest_client.py
@@ -630,18 +630,21 @@ class GlobusOnlineRestClient(object):
                 urllib.urlencode(query_params), None)
         return urlparse.urlunsplit(parts)
 
-    def goauth_get_access_token_from_code(self, code):
+    def goauth_get_access_token_from_code(self, code, redirect_uri=None):
         """
         After receiving a code from the end user, this method will acquire an
         access token from the server which can be used for subsequent requests.
 
         :param code: The code which the user received after authenticating with the server and authorizing the client.
+        :param redirect_uri: The redirect URI which will be used for token
+        exchange. Per OAuth2 spec, this must be passed here.
 
         :return: Tuple containing (access_token, refresh_token, expire_time)
         """
         url_parts = ('https', self.server, '/goauth/token', None, None)
         result = token_utils.request_access_token(self.client,
-                self.client_secret, code, urlparse.urlunsplit(url_parts))
+                self.client_secret, code, urlparse.urlunsplit(url_parts),
+                redirect_uri=redirect_uri)
         return (
                 result.access_token,
                 result.refresh_token,

--- a/lib/nexus/go_rest_client.py
+++ b/lib/nexus/go_rest_client.py
@@ -611,12 +611,15 @@ class GlobusOnlineRestClient(object):
         return token_utils.validate_token(token, self.cache, self.verify_ssl)
 
 
-    def goauth_generate_request_url(self, username=None):
+    def goauth_generate_request_url(self, username=None, redirect_uri=None):
         """
         In order for the user to authorize the client to access his data, he
         must first go to the custom url provided here.
 
         :param username: (Optional) This will pre-populate the user's info in the form
+        :param redirect_uri: This will add the redirect_uri to the generated
+        query parameters. Note that if this is passed here, it must also be
+        passed identically to goauth_get_access_token_from_code()
 
         :return: A custom authorization url
         """
@@ -626,6 +629,8 @@ class GlobusOnlineRestClient(object):
                 }
         if username is not None:
             query_params['username'] = username
+        if redirect_uri:
+            query_params['redirect_uri'] = redirect_uri
         parts = ('https', self.server, '/goauth/authorize',
                 urllib.urlencode(query_params), None)
         return urlparse.urlunsplit(parts)

--- a/lib/nexus/token_utils.py
+++ b/lib/nexus/token_utils.py
@@ -158,6 +158,7 @@ def validate_token(token, cache=InMemoryCache(), verify=True):
 
 def request_access_token(client_id, client_secret,
         auth_code, auth_uri="https://graph.api.globusonline.org/token",
+        redirect_uri=None,
         verify=False):
     """
     Given an authorization code, request an access token.
@@ -175,6 +176,9 @@ def request_access_token(client_id, client_secret,
             'grant_type': 'authorization_code',
             'code': auth_code,
             }
+    if redirect_uri:
+        payload['redirect_uri'] = redirect_uri
+
     response = requests.post(auth_uri,
             auth=(client_id, client_secret),
             data=payload, verify=verify)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as reqs:
 
 CONFIG = {
   'description':'client for GlobusOnline Nexus',
-  'version':'0.0.1',
+  'version':'0.0.2',
   'name':'nexus-client',
   'package_dir': {'':'lib'},
   'packages': ['nexus'],


### PR DESCRIPTION
When getting an access token from code, OAuth2 spec dictates that the
redirect_uri is required.

This is still being tested, so not necessarily safe to merge yet.
