### PR TITLE
Pre-Globus Auth Deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,29 @@ python-nexus-client
 
 Example python client for interacting with Globus Nexus service.
 
-The main entry point to this library is nexus.Client.  This allows
+The main entry point to this library is `nexus.Client`.  This allows
 access to all of the main methods.
 
 When a user authenticates with Nexus, they are issued a token.  An API
 client can validate a user's authentication by taking that token and
-calling client.authenticate_user(token).
+calling `client.authenticate_user(token)`.
+
+This Library is Only an Example
+---
+
+This library is officially an example, and the Globus Team is not committed to
+supporting it.
+It is maintained on a "best effort" basis, and it is not guaranteed to work
+correctly as our service evolves.
+
+Updates for February 13th, 2016
+---
+
+On 2016-02-13, Globus is slated to launch a new centralized authentication and
+authorization service named Globus Auth.
+We will be maintaining limited backwards compatibility for clients of the Nexus
+service, and this library will contain some instructional information regarding
+the transition.
+
+As always, this library is example code intended as a reference, and not
+guaranteed to be fully functional.

--- a/lib/nexus/go_rest_client.py
+++ b/lib/nexus/go_rest_client.py
@@ -611,29 +611,24 @@ class GlobusOnlineRestClient(object):
         return token_utils.validate_token(token, self.cache, self.verify_ssl)
 
 
-    def goauth_generate_request_url(self, username=None, redirect_uri=None):
+    def goauth_generate_request_url(self, *args, **kwargs):
         """
-        In order for the user to authorize the client to access his data, he
-        must first go to the custom url provided here.
+        In order to obtain an access token, you first need to obtain a code to
+        exchange for it as part of a 3-legged OAuth flow.
+        This method used to provide a means of fetching the token by means of a
+        request to the Nexus service via Basic Authentication. However, that
+        approach is no longer viable, so this method is defunct.
 
-        :param username: (Optional) This will pre-populate the user's info in the form
-        :param redirect_uri: This will add the redirect_uri to the generated
-        query parameters. Note that if this is passed here, it must also be
-        passed identically to goauth_get_access_token_from_code()
-
-        :return: A custom authorization url
+        Rather than continuing to function, but providing non-meaningful
+        information, this method should raise a NotImplementedError to
+        guarantee that library users see and understand the change.
         """
-        query_params = {
-                "response_type": "code",
-                "client_id": self.client,
-                }
-        if username is not None:
-            query_params['username'] = username
-        if redirect_uri:
-            query_params['redirect_uri'] = redirect_uri
-        parts = ('https', self.server, '/goauth/authorize',
-                urllib.urlencode(query_params), None)
-        return urlparse.urlunsplit(parts)
+        raise NotImplementedError(
+            'As of Feburary, 2016, this feature is no longer available. '
+            'If you require an access token, the best way is to make use of '
+            '`https://www.globus.org/OAuth`.\n'
+            'If you are unsure how to do so, please contact us at '
+            'support@globus.org')
 
     def goauth_get_access_token_from_code(self, code, redirect_uri=None):
         """

--- a/lib/nexus/token_utils.py
+++ b/lib/nexus/token_utils.py
@@ -172,12 +172,23 @@ def request_access_token(client_id, client_secret,
     fields: access_token, refresh_token and expires_in
     :raises TokenRequestError: If the request for an access token fails
     """
+    if not redirect_uri:
+        raise ValueError(
+            'Missing redirect_uri for access token exchange. '
+            'This likely occurred because of a call to '
+            'goauth_get_access_token_from_code() which did not pass the '
+            'redirect_uri keyword argument. '
+            'Although this used to be supported behavior, the OAuth '
+            'specification requires that any redirect URI passed during '
+            'code generation also be passed during the token exchange. '
+            'Because Nexus does not support requests for the code '
+            'without a redirect URI, this is a required parameter.')
+
     payload = {
             'grant_type': 'authorization_code',
             'code': auth_code,
+            'redirect_uri': redirect_uri,
             }
-    if redirect_uri:
-        payload['redirect_uri'] = redirect_uri
 
     response = requests.post(auth_uri,
             auth=(client_id, client_secret),

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open('requirements.txt') as reqs:
     install_requires = [line for line in reqs]
 
 CONFIG = {
-  'description':'client for GlobusOnline Nexus',
-  'version':'0.0.2',
+  'description':'client for Globus Nexus',
+  'version':'0.0.3',
   'name':'nexus-client',
   'package_dir': {'':'lib'},
   'packages': ['nexus'],


### PR DESCRIPTION
This is a little bit heavy-handed, but we want to make sure people aren't using unsupported features that are being dropped in our upcoming release.

I'm not sure that these are the only relevant locations, but they're definitely some of them.
Raising errors ensures that anyone who is pulling in the latest version of the sample lib will be forced to fix their usage.

I also did some fixing to the README to better indicate to people that this is a sample, and stripped the example usage down to remove functionality that I know is going away.
I replaced it with a simple Basic Auth usage, which I tested and know works.
