### PR TITLE
Add MANIFEST.in so that bdist_rpm works

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
Pull request so that you can run python setup.py bdist_rpm and get a rpm for the nexus client.  Without the file, you get the following error:
- python setup.py build
  Traceback (most recent call last):
  File "setup.py", line 3, in <module>
   with open('requirements.txt') as reqs:
  IOError: [Errno 2] No such file or directory: 'requirements.txt'
  error: Bad exit status from /var/tmp/rpm-tmp.zfWwpd (%build)

RPM build errors:
   Bad exit status from /var/tmp/rpm-tmp.zfWwpd (%build)
error: command 'rpmbuild' failed with exit status 1
